### PR TITLE
initial inline implementation for memset()

### DIFF
--- a/string/memset.c
+++ b/string/memset.c
@@ -28,7 +28,7 @@ memset (void *dstpp, int c, size_t len)
 
   if (len >= 8)
     {
-      #ifdef __AARCH64__
+      #ifdef ARM64
       #else
       size_t xlen;
       op_t cccc;
@@ -52,7 +52,7 @@ memset (void *dstpp, int c, size_t len)
       /* Write 8 `op_t' per iteration until less than 8 `op_t' remain.  */
       xlen = len / (OPSIZ * 8);
 
-#ifdef __AARCH64__
+#ifdef ARM64
       __asm__ ("DUP v0.2d, %0;  \
 					MOV v1.16b, v0.16b; \
 					MOV v2.16b, v0.16b; \

--- a/string/memset.c
+++ b/string/memset.c
@@ -28,6 +28,8 @@ memset (void *dstpp, int c, size_t len)
 
   if (len >= 8)
     {
+      #ifdef __AARCH64__
+      #else
       size_t xlen;
       op_t cccc;
 
@@ -37,7 +39,7 @@ memset (void *dstpp, int c, size_t len)
       if (OPSIZ > 4)
 	/* Do the shift in two steps to avoid warning if long has 32 bits.  */
 	cccc |= (cccc << 16) << 16;
-
+      #endif
       /* There are at least some bytes to set.
 	 No need to test for LEN == 0 in this alignment loop.  */
       while (dstp % OPSIZ != 0)
@@ -50,6 +52,7 @@ memset (void *dstpp, int c, size_t len)
       /* Write 8 `op_t' per iteration until less than 8 `op_t' remain.  */
       xlen = len / (OPSIZ * 8);
 
+#ifdef __AARCH64__
       __asm__ ("DUP v0.2d, %0;  \
 					MOV v1.16b, v0.16b; \
 					MOV v2.16b, v0.16b; \
@@ -59,20 +62,6 @@ memset (void *dstpp, int c, size_t len)
 					 :
 			 );
 
-      /*while (xlen > 0)
-	{
-	  ((op_t *) dstp)[0] = cccc;
-	  ((op_t *) dstp)[1] = cccc;
-	  ((op_t *) dstp)[2] = cccc;
-	  ((op_t *) dstp)[3] = cccc;
-	  ((op_t *) dstp)[4] = cccc;
-	  ((op_t *) dstp)[5] = cccc;
-	  ((op_t *) dstp)[6] = cccc;
-	  ((op_t *) dstp)[7] = cccc;
-	  dstp += 8 * OPSIZ;
-	  xlen -= 1;
-	}*/
-
       __asm__ ("LOOP: \
             ST1 {v0.2d, v1.2d, v2.2d, v3.2d}, [%0], #64; \
             CMP %0, %1; \
@@ -81,7 +70,21 @@ memset (void *dstpp, int c, size_t len)
            : "r"(dstp), "r"(dstp + (len & ~0b11111)) /*register holding pointer (refer as %0), then volint register (refer as %1)*/
            :
        );
-
+#else
+       while (xlen > 0)
+     {
+     ((op_t *) dstp)[0] = cccc;
+     ((op_t *) dstp)[1] = cccc;
+     ((op_t *) dstp)[2] = cccc;
+     ((op_t *) dstp)[3] = cccc;
+     ((op_t *) dstp)[4] = cccc;
+     ((op_t *) dstp)[5] = cccc;
+     ((op_t *) dstp)[6] = cccc;
+     ((op_t *) dstp)[7] = cccc;
+     dstp += 8 * OPSIZ;
+     xlen -= 1;
+     }
+#endif
       len %= OPSIZ * 8;
 
       /* Write 1 `op_t' per iteration until less than OPSIZ bytes remain.  */


### PR DESCRIPTION
The first block of assembler code fills v0 with c (the character to be filled with) which is then used in the MOV commands to fill v1 -3 with c. 

We then use a loop in the second block to fill %0 (which is dstp) with c 8 bytes at a time via the STR command for v0-3. Self increment 64 bytes and compare with the length divided by 64 (using bitwise operations to improve speed). Once we have equal len and number of bytes filled, the original code takes care of anything under 64 bytes.